### PR TITLE
Add a try-catch in getGameProfileByUuid

### DIFF
--- a/src/main/java/com/forgeessentials/util/UserIdent.java
+++ b/src/main/java/com/forgeessentials/util/UserIdent.java
@@ -310,9 +310,14 @@ public class UserIdent {
         GameProfile profile = getGameProfileByUuid(uuid);
         if (profile != null)
             return profile.getName();
-        for (UserIdent ident : APIRegistry.perms.getServerZone().getKnownPlayers())
-            if (ident.getUuid().equals(uuid))
-                return ident.getUsername();
+        for (UserIdent ident : APIRegistry.perms.getServerZone().getKnownPlayers()) {
+        	try {
+        		if (ident.getUuid().equals(uuid))
+        			return ident.getUsername();
+        	} catch (Exception e) {
+        		return null;
+        	}
+        }
         return null;
     }
 


### PR DESCRIPTION
Here's the problem I had: I was assembling an update for my server earlier today, and all of the mods were working fine. However, once I added in ForgeEssentials to the mix, the server [kept crashing with NullPointerException](http://pastebin.com/YNY09CR9) once the map was initialized. At first I thought it had something to do with issue #1319, but as I investigated more, I realized that is not the case.

It seems like, after I pulled some files from my server, Forge Essentials couldn't find their UUIDs because they were technically never on the server I was testing on (their usernames weren't in the username cache). So I did what any reasonable man would do - forked the project and added a try-catch around the failing method. I've tested this in both client and server, and everything seems to be working fine after this.

Please note that I don't really know if this actually breaks every single thing that relies on this method as I'm a novice Java coder, but I don't see a reason why it would. This is also kind of a corner case, so I understand if this doesn't get accepted. Thank you for considering it nonetheless.