### PR TITLE
Fire events (ref #1665)

### DIFF
--- a/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_01.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_01.java
@@ -24,8 +24,19 @@ public abstract class MixinBlockFire_01 extends Block
         super(material);
     }
 
-    @Inject(method = "Lnet/minecraft/block/BlockFire;tryCatchFire(Lnet/minecraft/world/World;IIIILjava/util/Random;ILnet/minecraftforge/common/util/ForgeDirection;)V", at = @At("HEAD"), remap = false)
-    public void handleTryCatchFire(World world, int x, int y, int z, int p_149841_5_, Random p_149841_6_, int p_149841_7_, ForgeDirection face, CallbackInfo ci)
+    @Inject(method = "Lnet/minecraft/block/BlockFire;tryCatchFire(Lnet/minecraft/world/World;IIIILjava/util/Random;ILnet/minecraftforge/common/util/ForgeDirection;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlock(IIILnet/minecraft/block/Block;II)Z"), cancellable = true, remap = false)
+    public void handleTryCatchFireA(World world, int x, int y, int z, int p_149841_5_, Random p_149841_6_, int p_149841_7_, ForgeDirection face, CallbackInfo ci)
+    {
+        if (MinecraftForge.EVENT_BUS.post(new BlockDestroyedByFireEvent(x, y, z, world, this,p_149841_7_ )))
+        {
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "Lnet/minecraft/block/BlockFire;tryCatchFire(Lnet/minecraft/world/World;IIIILjava/util/Random;ILnet/minecraftforge/common/util/ForgeDirection;)V",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockToAir(III)Z"), cancellable = true, remap = false)
+    public void handleTryCatchFireB(World world, int x, int y, int z, int p_149841_5_, Random p_149841_6_, int p_149841_7_, ForgeDirection face, CallbackInfo ci)
     {
         if (MinecraftForge.EVENT_BUS.post(new BlockDestroyedByFireEvent(x, y, z, world, this,p_149841_7_ )))
         {

--- a/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_01.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_01.java
@@ -1,0 +1,35 @@
+package com.forgeessentials.core.preloader.mixin.block;
+
+import java.util.Random;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFire;
+import net.minecraft.block.material.Material;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fe.event.world.BlockDestroyedByFireEvent;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BlockFire.class)
+public abstract class MixinBlockFire_01 extends Block
+{
+    // dummy constructor, leave me alone
+    public MixinBlockFire_01(Material material)
+    {
+        super(material);
+    }
+
+    @Inject(method = "Lnet.minecraft.block.BlockFire;tryCatchFire (Lnet/minecraft/world/World;IIIILjava/util/Random;I)V", at = @At("HEAD"), remap = false)
+    public void handleTryCatchFire(World world, int x, int y, int z, int p_149841_5_, Random p_149841_6_, int p_149841_7_, ForgeDirection face, CallbackInfo ci)
+    {
+        if (MinecraftForge.EVENT_BUS.post(new BlockDestroyedByFireEvent(x, y, z, world, this,p_149841_7_ )))
+        {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_01.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_01.java
@@ -28,7 +28,7 @@ public abstract class MixinBlockFire_01 extends Block
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlock(IIILnet/minecraft/block/Block;II)Z"), cancellable = true, remap = false)
     public void handleTryCatchFireA(World world, int x, int y, int z, int p_149841_5_, Random p_149841_6_, int p_149841_7_, ForgeDirection face, CallbackInfo ci)
     {
-        if (MinecraftForge.EVENT_BUS.post(new BlockDestroyedByFireEvent(x, y, z, world, this,p_149841_7_ )))
+        if (MinecraftForge.EVENT_BUS.post(new BlockDestroyedByFireEvent(x, y, z, world, this, p_149841_7_ )))
         {
             ci.cancel();
         }
@@ -38,7 +38,7 @@ public abstract class MixinBlockFire_01 extends Block
             at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;setBlockToAir(III)Z"), cancellable = true, remap = false)
     public void handleTryCatchFireB(World world, int x, int y, int z, int p_149841_5_, Random p_149841_6_, int p_149841_7_, ForgeDirection face, CallbackInfo ci)
     {
-        if (MinecraftForge.EVENT_BUS.post(new BlockDestroyedByFireEvent(x, y, z, world, this,p_149841_7_ )))
+        if (MinecraftForge.EVENT_BUS.post(new BlockDestroyedByFireEvent(x, y, z, world, this, p_149841_7_ )))
         {
             ci.cancel();
         }

--- a/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_01.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_01.java
@@ -24,7 +24,7 @@ public abstract class MixinBlockFire_01 extends Block
         super(material);
     }
 
-    @Inject(method = "Lnet.minecraft.block.BlockFire;tryCatchFire (Lnet/minecraft/world/World;IIIILjava/util/Random;I)V", at = @At("HEAD"), remap = false)
+    @Inject(method = "Lnet/minecraft/block/BlockFire;tryCatchFire(Lnet/minecraft/world/World;IIIILjava/util/Random;ILnet/minecraftforge/common/util/ForgeDirection;)V", at = @At("HEAD"), remap = false)
     public void handleTryCatchFire(World world, int x, int y, int z, int p_149841_5_, Random p_149841_6_, int p_149841_7_, ForgeDirection face, CallbackInfo ci)
     {
         if (MinecraftForge.EVENT_BUS.post(new BlockDestroyedByFireEvent(x, y, z, world, this,p_149841_7_ )))

--- a/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_02.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_02.java
@@ -31,7 +31,7 @@ public abstract class MixinBlockFire_02 extends Block
         super(material);
     }
 
-    @Shadow
+    @Shadow(remap = false) // Forge method
     public abstract boolean canCatchFire(IBlockAccess world, int x, int y, int z, ForgeDirection face);
 
     @Shadow
@@ -40,7 +40,7 @@ public abstract class MixinBlockFire_02 extends Block
     @Shadow
     abstract int getChanceOfNeighborsEncouragingFire(World p_149845_1_, int p_149845_2_, int p_149845_3_, int p_149845_4_);
 
-    @Shadow
+    @Shadow(remap = false) // Forge method
     abstract void tryCatchFire(World p_149841_1_, int p_149841_2_, int p_149841_3_, int p_149841_4_, int p_149841_5_, Random p_149841_6_, int p_149841_7_, ForgeDirection face);
 
     @Overwrite
@@ -141,6 +141,7 @@ public abstract class MixinBlockFire_02 extends Block
                                                 k2 = 15;
                                             }
 
+                                            // FE: Throw event
                                             if (!MinecraftForge.EVENT_BUS.post(new FireSpreadEvent(i1, k1, j1, p_149674_1_, this, k2, p_149674_2_, p_149674_3_, p_149674_4_)))
 
                                             p_149674_1_.setBlock(i1, k1, j1, this, k2, 3);

--- a/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_02.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_02.java
@@ -1,0 +1,157 @@
+package com.forgeessentials.core.preloader.mixin.block;
+
+import java.util.Random;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockFire;
+import net.minecraft.block.material.Material;
+import net.minecraft.world.IBlockAccess;
+import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fe.event.world.FireSpreadEvent;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import static net.minecraftforge.common.util.ForgeDirection.DOWN;
+import static net.minecraftforge.common.util.ForgeDirection.EAST;
+import static net.minecraftforge.common.util.ForgeDirection.NORTH;
+import static net.minecraftforge.common.util.ForgeDirection.SOUTH;
+import static net.minecraftforge.common.util.ForgeDirection.UP;
+import static net.minecraftforge.common.util.ForgeDirection.WEST;
+
+@Mixin(BlockFire.class)
+public abstract class MixinBlockFire_02 extends Block
+{
+    // dummy constructor, leave me alone
+    public MixinBlockFire_02(Material material)
+    {
+        super(material);
+    }
+
+    @Shadow
+    public abstract boolean canCatchFire(IBlockAccess world, int x, int y, int z, ForgeDirection face);
+
+    @Shadow
+    abstract boolean canNeighborBurn(World p_149847_1_, int p_149847_2_, int p_149847_3_, int p_149847_4_);
+
+    @Shadow
+    abstract int getChanceOfNeighborsEncouragingFire(World p_149845_1_, int p_149845_2_, int p_149845_3_, int p_149845_4_);
+
+    @Shadow
+    abstract void tryCatchFire(World p_149841_1_, int p_149841_2_, int p_149841_3_, int p_149841_4_, int p_149841_5_, Random p_149841_6_, int p_149841_7_, ForgeDirection face);
+
+    @Overwrite
+    public void updateTick(World p_149674_1_, int p_149674_2_, int p_149674_3_, int p_149674_4_, Random p_149674_5_)
+    {
+        if (p_149674_1_.getGameRules().getGameRuleBooleanValue("doFireTick"))
+        {
+            boolean flag = p_149674_1_.getBlock(p_149674_2_, p_149674_3_ - 1, p_149674_4_)
+                    .isFireSource(p_149674_1_, p_149674_2_, p_149674_3_ - 1, p_149674_4_, UP);
+
+            if (!this.canPlaceBlockAt(p_149674_1_, p_149674_2_, p_149674_3_, p_149674_4_))
+            {
+                p_149674_1_.setBlockToAir(p_149674_2_, p_149674_3_, p_149674_4_);
+            }
+
+            if (!flag && p_149674_1_.isRaining() && (p_149674_1_.canLightningStrikeAt(p_149674_2_, p_149674_3_, p_149674_4_) || p_149674_1_
+                    .canLightningStrikeAt(p_149674_2_ - 1, p_149674_3_, p_149674_4_) || p_149674_1_
+                    .canLightningStrikeAt(p_149674_2_ + 1, p_149674_3_, p_149674_4_) || p_149674_1_
+                    .canLightningStrikeAt(p_149674_2_, p_149674_3_, p_149674_4_ - 1) || p_149674_1_
+                    .canLightningStrikeAt(p_149674_2_, p_149674_3_, p_149674_4_ + 1)))
+            {
+                p_149674_1_.setBlockToAir(p_149674_2_, p_149674_3_, p_149674_4_);
+            }
+            else
+            {
+                int l = p_149674_1_.getBlockMetadata(p_149674_2_, p_149674_3_, p_149674_4_);
+
+                if (l < 15)
+                {
+                    p_149674_1_.setBlockMetadataWithNotify(p_149674_2_, p_149674_3_, p_149674_4_, l + p_149674_5_.nextInt(3) / 2, 4);
+                }
+
+                p_149674_1_.scheduleBlockUpdate(p_149674_2_, p_149674_3_, p_149674_4_, this, this.tickRate(p_149674_1_) + p_149674_5_.nextInt(10));
+
+                if (!flag && !this.canNeighborBurn(p_149674_1_, p_149674_2_, p_149674_3_, p_149674_4_))
+                {
+                    if (!World.doesBlockHaveSolidTopSurface(p_149674_1_, p_149674_2_, p_149674_3_ - 1, p_149674_4_) || l > 3)
+                    {
+                        p_149674_1_.setBlockToAir(p_149674_2_, p_149674_3_, p_149674_4_);
+                    }
+                }
+                else if (!flag && !this.canCatchFire(p_149674_1_, p_149674_2_, p_149674_3_ - 1, p_149674_4_, UP) && l == 15 && p_149674_5_.nextInt(4) == 0)
+                {
+                    p_149674_1_.setBlockToAir(p_149674_2_, p_149674_3_, p_149674_4_);
+                }
+                else
+                {
+                    boolean flag1 = p_149674_1_.isBlockHighHumidity(p_149674_2_, p_149674_3_, p_149674_4_);
+                    byte b0 = 0;
+
+                    if (flag1)
+                    {
+                        b0 = -50;
+                    }
+
+                    this.tryCatchFire(p_149674_1_, p_149674_2_ + 1, p_149674_3_, p_149674_4_, 300 + b0, p_149674_5_, l, WEST);
+                    this.tryCatchFire(p_149674_1_, p_149674_2_ - 1, p_149674_3_, p_149674_4_, 300 + b0, p_149674_5_, l, EAST);
+                    this.tryCatchFire(p_149674_1_, p_149674_2_, p_149674_3_ - 1, p_149674_4_, 250 + b0, p_149674_5_, l, UP);
+                    this.tryCatchFire(p_149674_1_, p_149674_2_, p_149674_3_ + 1, p_149674_4_, 250 + b0, p_149674_5_, l, DOWN);
+                    this.tryCatchFire(p_149674_1_, p_149674_2_, p_149674_3_, p_149674_4_ - 1, 300 + b0, p_149674_5_, l, SOUTH);
+                    this.tryCatchFire(p_149674_1_, p_149674_2_, p_149674_3_, p_149674_4_ + 1, 300 + b0, p_149674_5_, l, NORTH);
+
+                    for (int i1 = p_149674_2_ - 1; i1 <= p_149674_2_ + 1; ++i1)
+                    {
+                        for (int j1 = p_149674_4_ - 1; j1 <= p_149674_4_ + 1; ++j1)
+                        {
+                            for (int k1 = p_149674_3_ - 1; k1 <= p_149674_3_ + 4; ++k1)
+                            {
+                                if (i1 != p_149674_2_ || k1 != p_149674_3_ || j1 != p_149674_4_)
+                                {
+                                    int l1 = 100;
+
+                                    if (k1 > p_149674_3_ + 1)
+                                    {
+                                        l1 += (k1 - (p_149674_3_ + 1)) * 100;
+                                    }
+
+                                    int i2 = this.getChanceOfNeighborsEncouragingFire(p_149674_1_, i1, k1, j1);
+
+                                    if (i2 > 0)
+                                    {
+                                        int j2 = (i2 + 40 + p_149674_1_.difficultySetting.getDifficultyId() * 7) / (l + 30);
+
+                                        if (flag1)
+                                        {
+                                            j2 /= 2;
+                                        }
+
+                                        if (j2 > 0 && p_149674_5_.nextInt(l1) <= j2 && (!p_149674_1_.isRaining() || !p_149674_1_
+                                                .canLightningStrikeAt(i1, k1, j1)) && !p_149674_1_.canLightningStrikeAt(i1 - 1, k1, p_149674_4_) && !p_149674_1_
+                                                .canLightningStrikeAt(i1 + 1, k1, j1) && !p_149674_1_.canLightningStrikeAt(i1, k1, j1 - 1) && !p_149674_1_
+                                                .canLightningStrikeAt(i1, k1, j1 + 1))
+                                        {
+                                            int k2 = l + p_149674_5_.nextInt(5) / 4;
+
+                                            if (k2 > 15)
+                                            {
+                                                k2 = 15;
+                                            }
+
+                                            if (!MinecraftForge.EVENT_BUS.post(new FireSpreadEvent(i1, k1, j1, p_149674_1_, this, k2, p_149674_2_, p_149674_3_, p_149674_4_)))
+
+                                            p_149674_1_.setBlock(i1, k1, j1, this, k2, 3);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_02.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/block/MixinBlockFire_02.java
@@ -143,8 +143,9 @@ public abstract class MixinBlockFire_02 extends Block
 
                                             // FE: Throw event
                                             if (!MinecraftForge.EVENT_BUS.post(new FireSpreadEvent(i1, k1, j1, p_149674_1_, this, k2, p_149674_2_, p_149674_3_, p_149674_4_)))
-
-                                            p_149674_1_.setBlock(i1, k1, j1, this, k2, 3);
+                                            {
+                                                p_149674_1_.setBlock(i1, k1, j1, this, k2, 3);
+                                            }
                                         }
                                     }
                                 }

--- a/src/main/java/com/forgeessentials/core/preloader/mixin/package-info.java
+++ b/src/main/java/com/forgeessentials/core/preloader/mixin/package-info.java
@@ -20,5 +20,9 @@
  * MixinCommandHandler_01 and MixinEntityPlayer_01: For net.minecraftforge.fe Permissions API
  *
  * MixinEntity_01: For net.minecraftforge.fe EntityTriggerPressurePlateEvent
+ *
+ * MixinBlockFire_01: For net.minecraftforge.fe.BlockDestroyedByFireEvent
+ *
+ * MixinBlockFire_02: For net.minecraftforge.fe FireSpreadEvent
  */
 package com.forgeessentials.core.preloader.mixin;

--- a/src/main/java/net/minecraftforge/fe/event/world/BlockDestroyedByFireEvent.java
+++ b/src/main/java/net/minecraftforge/fe/event/world/BlockDestroyedByFireEvent.java
@@ -6,6 +6,10 @@ import net.minecraftforge.event.world.BlockEvent;
 
 import cpw.mods.fml.common.eventhandler.Cancelable;
 
+/**
+ * Fired when a block is destroyed by fire.
+ */
+
 @Cancelable
 public class BlockDestroyedByFireEvent extends BlockEvent
 {

--- a/src/main/java/net/minecraftforge/fe/event/world/BlockDestroyedByFireEvent.java
+++ b/src/main/java/net/minecraftforge/fe/event/world/BlockDestroyedByFireEvent.java
@@ -1,0 +1,16 @@
+package net.minecraftforge.fe.event.world;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import net.minecraftforge.event.world.BlockEvent;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+
+@Cancelable
+public class BlockDestroyedByFireEvent extends BlockEvent
+{
+    public BlockDestroyedByFireEvent(int x, int y, int z, World world, Block block, int meta)
+    {
+        super(x, y, z, world, block, meta);
+    }
+}

--- a/src/main/java/net/minecraftforge/fe/event/world/FireSpreadEvent.java
+++ b/src/main/java/net/minecraftforge/fe/event/world/FireSpreadEvent.java
@@ -1,0 +1,26 @@
+package net.minecraftforge.fe.event.world;
+
+import net.minecraft.block.Block;
+import net.minecraft.world.World;
+import net.minecraftforge.event.world.BlockEvent;
+
+import cpw.mods.fml.common.eventhandler.Cancelable;
+
+/**
+ * Fired when a block is about to catch fire from another block.
+ */
+
+@Cancelable
+public class FireSpreadEvent extends BlockEvent
+{
+
+    public final int sourceX, sourceY, sourceZ;
+
+    public FireSpreadEvent(int affectedX, int affectedY, int affectedZ, World world, Block block, int meta, int sourceX, int sourceY, int sourceZ)
+    {
+        super(affectedX, affectedY, affectedZ, world, block, meta);
+        this.sourceX = sourceX;
+        this.sourceY = sourceY;
+        this.sourceZ = sourceZ;
+    }
+}

--- a/src/main/java/net/minecraftforge/fe/package-info.java
+++ b/src/main/java/net/minecraftforge/fe/package-info.java
@@ -5,7 +5,7 @@
  *
  * apiVersion will change when the build of forge we build FE on changes, or we add new hooks/APIs.
  */
-@API(owner = "ForgeEssentials", provides = "Forge-FEHooks", apiVersion = "1291.1")
+@API(owner = "ForgeEssentials", provides = "Forge-FEHooks", apiVersion = "1448.2")
 package net.minecraftforge.fe;
 
 import cpw.mods.fml.common.API;

--- a/src/main/resources/mixins.forgeessentials.json
+++ b/src/main/resources/mixins.forgeessentials.json
@@ -9,6 +9,7 @@
 		"entity.MixinEntityTracker_01",
 		"entity.MixinEntity_01",
         "server.management.MixinItemInWorldManager_01",
-        "item.crafting.MixinCraftingManager"
+        "item.crafting.MixinCraftingManager",
+        "block.MixinBlockFire_01"
 	]
 }

--- a/src/main/resources/mixins.forgeessentials.json
+++ b/src/main/resources/mixins.forgeessentials.json
@@ -10,6 +10,7 @@
 		"entity.MixinEntity_01",
         "server.management.MixinItemInWorldManager_01",
         "item.crafting.MixinCraftingManager",
-        "block.MixinBlockFire_01"
+        "block.MixinBlockFire_01",
+        "block.MixinBlockFire_02"
 	]
 }


### PR DESCRIPTION
Adds 2 new events:

- BlockDestroyedByFireEvent: Fired when a block is destroyed by fire
- FireSpreadEvent: Fired when fire spreads to another block

Both are cancellable.

MixinBlockFire_01 is written with the new approach as described in #1619.

Permissions and playerlogger hooks will only be done after this is merged.